### PR TITLE
fix: strip Authorization: Basic header in machineIdentityTransport

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -556,11 +556,18 @@ func (t *machineIdentityTransport) RoundTrip(req *http.Request) (*http.Response,
 	vals.Set("client_assertion", assertion)
 
 	newBody := vals.Encode()
+
+	// Clone before mutating so we don't modify the original request.
+	req = req.Clone(req.Context())
 	req.Body = io.NopCloser(strings.NewReader(newBody))
 	req.ContentLength = int64(len(newBody))
 	req.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(strings.NewReader(newBody)), nil
 	}
+	// Strip the Authorization: Basic header the oauth2 library adds from
+	// config.Credentials.Secret — Authn authenticates the client via the
+	// client_assertion alone; sending Basic auth alongside it confuses it.
+	req.Header.Del("Authorization")
 
 	return t.base.RoundTrip(req)
 }


### PR DESCRIPTION
The oauth2 library always adds Authorization: Basic base64(client_id:client_secret) from config.Credentials.Secret. machineIdentityTransport was rewriting the POST body correctly (client_assertion) but leaving the Basic header intact, causing Authn to see conflicting auth methods and reject the request.

Clone the request before mutation and del the Authorization header so only client_assertion authenticates the client, per RFC 7523.