### PR TITLE
feat(db/mysql): enable TLS for token-auth DBs based on port prefix

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -726,6 +726,11 @@ const (
 	// TokenAuthEnabledLabel is used identify whether enable token based authentication instead of regular
 	// certificate based authentication
 	TokenAuthEnabledLabel = TeleportNamespace + "/token-auth-enabled"
+
+	// ProxySQLEnabledLabel identifies whether a database is fronted by a TLS-terminating
+	// SQL proxy (e.g. ProxySQL). When set to true, the agent establishes the upstream
+	// connection over TLS; otherwise the upstream connection is made in plaintext.
+	ProxySQLEnabledLabel = TeleportNamespace + "/proxysql-enabled"
 )
 
 var (

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -139,6 +139,9 @@ type Database interface {
 	GetCloud() string
 	// IsTokenAuthEnabled returns true if for a certain db token auth should be used instead of certificate auth
 	IsTokenAuthEnabled() bool
+	// IsProxySQLEnabled returns true if the database is fronted by a TLS-terminating
+	// SQL proxy (e.g. ProxySQL) and the upstream connection should be made over TLS.
+	IsProxySQLEnabled() bool
 }
 
 // NewDatabaseV3 creates a new database resource.
@@ -160,6 +163,12 @@ func (d *DatabaseV3) GetVersion() string {
 
 func (d *DatabaseV3) IsTokenAuthEnabled() bool {
 	return d.Metadata.IsTokenAuthEnabled()
+}
+
+// IsProxySQLEnabled returns true if the database is fronted by a TLS-terminating
+// SQL proxy (e.g. ProxySQL) and the upstream connection should be made over TLS.
+func (d *DatabaseV3) IsProxySQLEnabled() bool {
+	return d.Metadata.IsProxySQLEnabled()
 }
 
 // GetKind returns the database resource kind.

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -459,6 +459,17 @@ func (m *Metadata) IsTokenAuthEnabled() bool {
 	return tokenAuthEnabled
 }
 
+// IsProxySQLEnabled returns true when the database is fronted by a
+// TLS-terminating SQL proxy (e.g. ProxySQL) and the upstream connection
+// from the agent should be made over TLS.
+func (m *Metadata) IsProxySQLEnabled() bool {
+	if m.Labels == nil {
+		return false
+	}
+	proxySQLEnabled, _ := utils.ParseBool(m.Labels[ProxySQLEnabledLabel])
+	return proxySQLEnabled
+}
+
 // CheckAndSetDefaults checks validity of all parameters and sets defaults
 func (m *Metadata) CheckAndSetDefaults() error {
 	if m.Name == "" {

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/client"
@@ -283,10 +282,11 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		// Enable TLS only when the database port starts with "60", otherwise
-		// disable it by using a no-op connect option. The default connectOpt
-		// (which applies tlsConfig) is kept for TLS-enabled ports.
-		if !isTLSPort(sessionCtx.Database.GetURI()) {
+		// Enable TLS only when the database is fronted by a TLS-terminating SQL
+		// proxy (e.g. ProxySQL). Otherwise disable it by using a no-op connect
+		// option. The default connectOpt (which applies tlsConfig) is kept for
+		// proxied databases.
+		if !sessionCtx.Database.IsProxySQLEnabled() {
 			connectOpt = func(conn *client.Conn) {}
 		}
 	}
@@ -315,23 +315,6 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 		return nil, common.ConvertConnectError(err, sessionCtx)
 	}
 	return conn, nil
-}
-
-// tlsPortPrefix is the database port prefix that indicates the upstream server
-// expects a TLS connection. Ports beginning with this prefix (e.g. 60xx) enable
-// TLS; all others connect in plaintext.
-const tlsPortPrefix = "60"
-
-// isTLSPort reports whether TLS should be enabled for the given database URI.
-// TLS is considered enabled when the port portion of the URI starts with
-// tlsPortPrefix, and disabled otherwise.
-func isTLSPort(uri string) bool {
-	_, port, err := net.SplitHostPort(uri)
-	if err != nil {
-		// Fall back to no TLS if the URI does not contain a parseable port.
-		return false
-	}
-	return strings.HasPrefix(port, tlsPortPrefix)
 }
 
 func withClientCapabilities(caps ...uint32) func(conn *client.Conn) {

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/client"
@@ -279,9 +280,14 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 		user = services.MakeAzureDatabaseLoginUsername(sessionCtx.Database, user)
 	case e.Auth.IsTokenAuthEnabled() && sessionCtx.Database.IsTokenAuthEnabled():
 		user, password, err = e.Auth.GetTokenAuthCredentials(ctx, sessionCtx)
-		connectOpt = func(conn *client.Conn) {}
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+		// Enable TLS only when the database port starts with "60", otherwise
+		// disable it by using a no-op connect option. The default connectOpt
+		// (which applies tlsConfig) is kept for TLS-enabled ports.
+		if !isTLSPort(sessionCtx.Database.GetURI()) {
+			connectOpt = func(conn *client.Conn) {}
 		}
 	}
 
@@ -309,6 +315,23 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 		return nil, common.ConvertConnectError(err, sessionCtx)
 	}
 	return conn, nil
+}
+
+// tlsPortPrefix is the database port prefix that indicates the upstream server
+// expects a TLS connection. Ports beginning with this prefix (e.g. 60xx) enable
+// TLS; all others connect in plaintext.
+const tlsPortPrefix = "60"
+
+// isTLSPort reports whether TLS should be enabled for the given database URI.
+// TLS is considered enabled when the port portion of the URI starts with
+// tlsPortPrefix, and disabled otherwise.
+func isTLSPort(uri string) bool {
+	_, port, err := net.SplitHostPort(uri)
+	if err != nil {
+		// Fall back to no TLS if the URI does not contain a parseable port.
+		return false
+	}
+	return strings.HasPrefix(port, tlsPortPrefix)
 }
 
 func withClientCapabilities(caps ...uint32) func(conn *client.Conn) {


### PR DESCRIPTION
Token-auth MySQL databases previously always connected without TLS via a no-op connect option. Enable TLS for these databases when the database URI port starts with "60", keeping the default connectOpt that applies the TLS config. Other ports continue to connect in plaintext.